### PR TITLE
feat(ext4): implement readlink and fix checksum handling

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -8,7 +8,7 @@ use crate::prelude::*;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ErrCode {
     /// Operation not permitted.
-    EPERM = 1, 
+    EPERM = 1,
     /// No such file or directory.
     ENOENT = 2,
     /// I/O error.

--- a/src/ext4/alloc.rs
+++ b/src/ext4/alloc.rs
@@ -98,7 +98,7 @@ impl Ext4 {
         let fblock = self.extent_query_or_create(inode, iblock, 1)?;
         // Update block count
         inode.inode.set_fs_block_count(iblock as u64 + 1);
-        self.write_inode_without_csum(inode);
+        self.write_inode_with_csum(inode);
 
         Ok((iblock, fblock))
     }
@@ -287,7 +287,7 @@ impl Ext4 {
 
         // Clear inode content
         inode_ref.inode = Box::new(Inode::default());
-        self.write_inode_without_csum(inode_ref);
+        self.write_inode_with_csum(inode_ref);
 
         Ok(())
     }

--- a/src/ext4/extent.rs
+++ b/src/ext4/extent.rs
@@ -182,7 +182,7 @@ impl Ext4 {
             let mut leaf_node = inode_ref.inode.extent_root_mut();
             // Insert the extent
             let res = leaf_node.insert_extent(new_ext, leaf.index.unwrap_err());
-            self.write_inode_without_csum(inode_ref);
+            self.write_inode_with_csum(inode_ref);
             // Handle split
             return if let Err(split) = res {
                 self.split_root(inode_ref, &split)
@@ -255,7 +255,7 @@ impl Ext4 {
             let mut parent_node = inode_ref.inode.extent_root_mut();
             parent_depth = parent_node.header().depth();
             res = parent_node.insert_extent_index(&extent_index, child_pos + 1);
-            self.write_inode_without_csum(inode_ref);
+            self.write_inode_with_csum(inode_ref);
         } else {
             // Parent is not root
             let mut parent_block = self.read_block(parent_pblock);
@@ -315,7 +315,7 @@ impl Ext4 {
         // Sync to disk
         self.write_block(&l_block);
         self.write_block(&r_block);
-        self.write_inode_without_csum(inode_ref);
+        self.write_inode_with_csum(inode_ref);
 
         Ok(())
     }

--- a/src/ext4/high_level.rs
+++ b/src/ext4/high_level.rs
@@ -136,7 +136,7 @@ impl Ext4 {
     ///
     /// # Error
     ///
-    /// * `ENOTDIR` - Any parent in the path is not a directory. 
+    /// * `ENOTDIR` - Any parent in the path is not a directory.
     /// * `ENOENT` - The source object does not exist.
     /// * `EEXIST` - The destination object already exists.
     pub fn generic_rename(&self, root: InodeId, src: &str, dst: &str) -> Result<()> {

--- a/src/ext4/link.rs
+++ b/src/ext4/link.rs
@@ -27,14 +27,14 @@ impl Ext4 {
     }
 
     /// Unlink a child inode from a parent directory.
-    /// 
+    ///
     /// If `free` is true, the inode will be freed if it has no links.
     pub(super) fn unlink_inode(
         &self,
         parent: &mut InodeRef,
         child: &mut InodeRef,
         name: &str,
-        free: bool, 
+        free: bool,
     ) -> Result<()> {
         // Remove entry from parent directory
         self.dir_remove_entry(parent, name)?;

--- a/src/ext4/mod.rs
+++ b/src/ext4/mod.rs
@@ -52,7 +52,7 @@ impl Ext4 {
             block_device,
         })
     }
-    
+
     /// Initializes the root directory.
     pub fn init(&mut self) -> Result<()> {
         // Create root directory

--- a/src/ext4_defs/block.rs
+++ b/src/ext4_defs/block.rs
@@ -43,7 +43,7 @@ impl Default for Block {
 
 impl Block {
     /// Create new block with given physical block id and data.
-    pub fn new(block_id: PBlockId, data: Box::<[u8; BLOCK_SIZE]>) -> Self {
+    pub fn new(block_id: PBlockId, data: Box<[u8; BLOCK_SIZE]>) -> Self {
         Self { id: block_id, data }
     }
 

--- a/src/ext4_defs/block_group.rs
+++ b/src/ext4_defs/block_group.rs
@@ -136,6 +136,9 @@ impl BlockGroupRef {
     }
 
     pub fn set_checksum(&mut self, uuid: &[u8]) {
+        // Same as inode checksum: clear the checksum field before calculation to avoid
+        // including old value causing checksum mismatch.
+        self.desc.checksum = 0;
         let mut checksum = crc32(CRC32_INIT, uuid);
         checksum = crc32(checksum, &self.id.to_le_bytes());
         checksum = crc32(checksum, self.desc.to_bytes());

--- a/src/ext4_defs/dir.rs
+++ b/src/ext4_defs/dir.rs
@@ -85,9 +85,7 @@ impl DirEntry {
     /// Get the name of the directory entry
     pub fn name(&self) -> String {
         let name = &self.name[..self.name_len as usize];
-        unsafe {
-            String::from_utf8_unchecked(name.to_vec())
-        }
+        unsafe { String::from_utf8_unchecked(name.to_vec()) }
     }
 
     /// Compare the name of the directory entry with a given name

--- a/src/ext4_defs/extent.rs
+++ b/src/ext4_defs/extent.rs
@@ -301,7 +301,7 @@ impl<'a> ExtentNode<'a> {
                 break;
             }
         }
-        
+
         // debug!("Search res: {:?}", res);
         Err(i)
     }
@@ -322,7 +322,7 @@ impl<'a> ExtentNode<'a> {
             }
             i += 1;
         }
-        
+
         // debug!("Search res: {:?}", res);
         Ok(i - 1)
     }

--- a/src/ext4_defs/xattr.rs
+++ b/src/ext4_defs/xattr.rs
@@ -306,7 +306,7 @@ impl XattrBlock {
         // `p_entry` points to the start of blank area,
         // `p_value` points to the last value,
         // `[p_entry, p_value)` is the blank area.
-        
+
         // Check space, '+1' is reserved for blank area
         if p_value - p_entry < ins_entry_size + ins_value_size + 1 {
             // Not enough space
@@ -396,10 +396,9 @@ impl XattrBlock {
 
         // Move the corresponding values
         // Copy `[p_value, rem_value_pos)` to `[p_value + rem_value_size, rem_value_pos + rem_value_size)`
-        self.0.data.copy_within(
-            p_value..rem_value_pos,
-            p_value + rem_value_size,
-        );
+        self.0
+            .data
+            .copy_within(p_value..rem_value_pos, p_value + rem_value_size);
         // Set `[p_value, p_value + rem_value_size)` to 0
         self.0.data[p_value..p_value + rem_value_size].fill(0);
 


### PR DESCRIPTION
- Add`readlink`method for reading symbolic link content with fast symlink support
- Fix superblock, inode, and block group descriptor checksum calculations
- Replace`write_inode_without_csum`with`write_inode_with_csum`
in multiple locations
- Improve superblock write to preserve existing block content and update
checksum
- Add inline block accessor methods for inode
- Minor code style fixes and documentation updates
